### PR TITLE
Fix security

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ python-dateutil==2.8.1
 pytz==2020.1
 requests==2.24.0
 six==1.15.0
-urllib3==1.25.10
+urllib3>=1.26.5
 webencodings==0.5.1


### PR DESCRIPTION
Solve security vulnerability: "Catastrophic backtracking in URL authority parser when passed URL containing many @ characters" in _urllib_. 

Updated to a version not affected by the vulnerability.